### PR TITLE
Return a Map from HGETALL

### DIFF
--- a/lib/exredis/api.ex
+++ b/lib/exredis/api.ex
@@ -79,7 +79,7 @@ defmodule Exredis.Api do
   defredis :hgetall, [:key], fn x ->
     Enum.chunk(x, 2) 
       |> Enum.map(fn [a, b] -> {a, b} end) 
-      |> HashDict.new
+      |> Enum.into(Map.new)
   end
   defredis :hincrby, [:key, :field, :increment], &int_reply/1
   defredis :hincrbyfloat, [:key, :field, :increment]

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Exredis.Mixfile do
   def project do
     [ app: :exredis,
       version: "0.1.0-pre.4",
-      elixir: ">= 0.12.4",
+      elixir: ">= 0.13.0",
       deps: deps(Mix.env) ]
   end
 

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -261,7 +261,7 @@ defmodule ApiTest do
   test "hgetall", c do
     assert (c[:c] |> R.hset "myhash", "field1", "Hello") == 1
     assert (c[:c] |> R.hset "myhash", "field2", "World") == 1
-    assert (c[:c] |> R.hgetall "myhash") == HashDict.new [{"field1", "Hello"}, {"field2", "World"}]
+    assert (c[:c] |> R.hgetall "myhash") == %{"field1" => "Hello", "field2" => "World"}
   end
 
   test "hincrby", c do


### PR DESCRIPTION
This PR returns a `Map` from the `HGETALL` command. As such it requires Elixir >= 0.13.0 and Erlang >= 17
