### PR TITLE
allow trailing slash in connection string

### DIFF
--- a/lib/exredis/connection_string.ex
+++ b/lib/exredis/connection_string.ex
@@ -15,6 +15,7 @@ defmodule Exredis.ConnectionString do
   end
 
   defp parse_db(nil), do: 0
+  defp parse_db("/"), do: 0
   defp parse_db(path) do
     path |> String.split("/") |> Enum.at(1) |> String.to_integer
   end

--- a/test/connection_string_test.exs
+++ b/test/connection_string_test.exs
@@ -18,6 +18,14 @@ defmodule ConnectionStringTest do
     assert config.db == 10
   end
 
+  test "parsing a connection string with trailing slash" do
+    config = Exredis.ConnectionString.parse("redis://user:password@host:1234/")
+    assert config.host == "host"
+    assert config.port == 1234
+    assert config.password == "password"
+    assert config.db == 0
+  end
+
   test "parsing a connection string without user" do
     config = Exredis.ConnectionString.parse("redis://:password@host:1234")
     assert config.host == "host"


### PR DESCRIPTION
Exredis currently cannot parse redis connection strings ending with a trailing slash (eg: `redis://localhost:6379/`), which is a valid URL, and is given out by default by leading hosted redis providers (eg, Heroku and Redistogo). 


Before:
Fails because `String.to_integer("")` throws an error.
```elixir
Exredis.ConnectionString.parse("redis://localhost:6379/")
** (ArgumentError) argument error
    :erlang.binary_to_integer("")
    iex:19: Exredis.ConnectionString.parse_db/1
    iex:13: Exredis.ConnectionString.parse/1
```

After:
```elixir
Exredis.ConnectionString.parse("redis://localhost:6379/")
%Exredis.ConnectionString.Config{db: 0, host: "localhost", password: "", port: 6379}
```
