### PR TITLE
Update eredis dependency to 1.0.8

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Exredis.Mixfile do
 
   # Dependencies
   defp deps do
-    [{:eredis,  ">= 1.0.8"}]
+    [{:eredis, github: "wooga/eredis", tag: "v1.0.8"}]
   end
 
   defp package do


### PR DESCRIPTION
When I tried using exredis, I got the error here: https://github.com/wooga/eredis/issues/73

But it looks like eredis fixed it in their latest release 1.0.8.

exredis now works for me.