### PR TITLE
Exredis.query_pipe/2 return result without :ok like Exredis.query/2

### DIFF
--- a/lib/exredis.ex
+++ b/lib/exredis.ex
@@ -104,5 +104,5 @@ defmodule Exredis do
   """
   @spec query_pipe(pid, [list]) :: any
   def query_pipe(client, command) when is_pid(client) and is_list(command), do:
-    client |> :eredis.qp(command)
+    client |> :eredis.qp(command) |> Enum.map(&elem(&1, 1))
 end

--- a/test/exredis_test.exs
+++ b/test/exredis_test.exs
@@ -104,6 +104,6 @@ defmodule ExredisTest do
     client = E.start
 
     status = E.query_pipe(client, query)
-    assert status == [ok: "OK", ok: "1", ok: "2"]
+    assert status == ["OK", "1", "2"]
   end
 end


### PR DESCRIPTION
Exredis.query/2 removes the leading :ok from the result. This change does the same to Exredis.query_pipe/2 which makes it easier to work with pipelined results.