### PR TITLE
Add :eredis dependency in the OTP applications configuration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Exredis.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    []
+    [applications: [:eredis]]
   end
 
   # Dependencies


### PR DESCRIPTION
Done to resolve issues with a hidden dependency of exredis on eredis. See https://github.com/bitwalker/exrm#common-issues