### PR TITLE
Enable multiple channels in pub/sub

### DIFF
--- a/lib/exredis/sub.ex
+++ b/lib/exredis/sub.ex
@@ -61,7 +61,7 @@ defmodule Exredis.Sub do
   def subscribe(client, channel, term) do
     spawn_link fn ->
       :eredis_sub.controlling_process client
-      :eredis_sub.subscribe client, [channel]
+      :eredis_sub.subscribe client, subscription_channel(channel)
       receiver(client, term)
     end
   end
@@ -75,10 +75,14 @@ defmodule Exredis.Sub do
   def psubscribe(client, channel, term) do
     spawn_link fn ->
       :eredis_sub.controlling_process client
-      :eredis_sub.psubscribe client, [channel]
+      :eredis_sub.psubscribe client, subscription_channel(channel)
       receiver(client, term)
     end
   end
+
+  @spec subscription_channel(term) :: any
+  defp subscription_channel(channel) when is_list(channel), do: channel
+  defp subscription_channel(channel), do: [channel]
 
   @spec ack_message(pid) :: any
   defp ack_message(client) when is_pid(client), do:
@@ -91,7 +95,7 @@ defmodule Exredis.Sub do
         ack_message(pid)
         callback.(msg)
         receiver(pid, callback)
-        
+
     end
   end
 end

--- a/test/pubsub_test.exs
+++ b/test/pubsub_test.exs
@@ -10,7 +10,7 @@ defmodule PubsubTest do
     client_sub = S.start
     client = E.start
     pid = Kernel.self
-    
+
     client_sub |> S.subscribe "foo", fn(msg) ->
       send(pid, msg)
     end
@@ -29,15 +29,49 @@ defmodule PubsubTest do
         assert (msg |> elem 0) == :message
         assert (msg |> elem 1) == "foo"
         assert (msg |> elem 2) == "Hello World!"
-        
+
     end
   end
+
+
+  test "pub/sub with multiple channels" do
+    client_sub = S.start
+    client = E.start
+    pid = Kernel.self
+
+    client_sub |> S.subscribe ["foo", "bar"], fn(msg) ->
+      send(pid, msg)
+    end
+
+    receive do
+      msg ->
+        assert (msg |> elem 0) == :subscribed
+        assert (msg |> elem 1) == "foo"
+    end
+
+    receive do
+      msg ->
+        assert (msg |> elem 0) == :subscribed
+        assert (msg |> elem 1) == "bar"
+    end
+
+    client |> R.publish "foo", "Hello World!"
+
+    receive do
+      msg ->
+        assert (msg |> elem 0) == :message
+        assert (msg |> elem 1) == "foo"
+        assert (msg |> elem 2) == "Hello World!"
+
+    end
+  end
+
 
   test "pub/sub by a pattern" do
     client_sub = S.start
     client = E.start
     pid = Kernel.self
-    
+
     client_sub |> S.psubscribe "bar_*", fn(msg) ->
       send(pid, msg)
     end


### PR DESCRIPTION
The subscribe command in redis allows it to be subscribed to multiple channels. This pull request enables multiple channels by allowing to pass lists to the subscribe/psubscribe methods. It then checks if it is a list or the default and handles this accordingly.

Please bear with me as I am fairly new to the elixir language, any criticism and/or help in getting better is appreciated.