### PR TITLE
Enable starting a Sub connection using a connection string

### DIFF
--- a/lib/exredis/sub.ex
+++ b/lib/exredis/sub.ex
@@ -42,6 +42,25 @@ defmodule Exredis.Sub do
     |> elem 1
 
   @doc """
+  Connect to the Redis server for subscribe to a channel using a connection string:
+
+  * `start_using_connection_string("redis://user:password@127.0.0.1:6379/0")`
+  * `start_using_connection_string("redis://127.0.0.1:6379")`
+
+  The database number is ignored.
+
+  Returns the pid of the connected client.
+  """
+  @spec start_using_connection_string(binary, reconnect, max_queue, behaviour) :: pid
+  def start_using_connection_string(connection_string \\ "redis://127.0.0.1:6379",
+        reconnect \\ :no_reconnect, max_queue \\ :infinity,
+        behaviour \\ :drop) do
+    config = Exredis.ConnectionString.parse(connection_string)
+    start(config.host, config.port, config.password, reconnect, max_queue, behaviour)
+  end
+
+
+  @doc """
   Disconnect from the Redis server:
 
   * `stop(client)`

--- a/test/pubsub_test.exs
+++ b/test/pubsub_test.exs
@@ -16,6 +16,10 @@ defmodule PubsubTest do
     assert pid |> is_pid
   end
 
+  test "connect using connection string" do
+    assert S.start_using_connection_string("redis://127.0.0.1:6379") |> is_pid
+  end
+
   test "disconnect" do
     assert (S.start |> S.stop) == :ok
   end

--- a/test/pubsub_test.exs
+++ b/test/pubsub_test.exs
@@ -6,6 +6,20 @@ defmodule PubsubTest do
   alias Exredis.Sub, as: S
   alias Exredis.Api, as: R
 
+  test "connect" do
+    assert S.start |> is_pid
+  end
+
+  test "connect, erlang way" do
+    { :ok, pid } = S.start_link
+
+    assert pid |> is_pid
+  end
+
+  test "disconnect" do
+    assert (S.start |> S.stop) == :ok
+  end
+
   test "pub/sub" do
     client_sub = S.start
     client = E.start


### PR DESCRIPTION
This will make the connection APIs for Exredis and Exredis.Sub modules more similar/compatible.

BTW Test the other connection and disconnection functions