### PR TITLE
Add timeout parameter to Exredis.query

### DIFF
--- a/lib/exredis.ex
+++ b/lib/exredis.ex
@@ -110,6 +110,19 @@ defmodule Exredis do
     client |> :eredis.q(command) |> elem(1)
 
   @doc """
+
+  Performs a query with the given arguments on the connected `client`.
+
+  * `query(client, ["SET", "foo", "bar"], 100)`
+
+  See all the available commands in the [official Redis
+  documentation](http://redis.io/commands).
+  """
+  @spec query(pid, list, Integer) :: any
+  def query(client, command, timeout) when is_pid(client) and is_list(command) and is_integer(timeout), do:
+    client |> :eredis.q(command, timeout) |> elem(1)
+
+  @doc """
   Performs a pipeline query, executing the list of commands.
 
       query_pipe(client, [["SET", :a, "1"],

--- a/test/exredis_test.exs
+++ b/test/exredis_test.exs
@@ -106,4 +106,9 @@ defmodule ExredisTest do
     status = E.query_pipe(client, query)
     assert status == ["OK", "1", "2"]
   end
+
+  test "explicit timeout", ctx do
+    {reason, _} = catch_exit(ctx[:c] |> E.query ["INFO"], 0)
+    assert reason == :timeout
+  end
 end


### PR DESCRIPTION
Hi,

we needed the possibility to tweak the query timeout several some places. With this change to can simply do:

```elixir
Exredis.query(client, ["GET", "key"], 50)
```

Same interface as in ```eredis```.

Cheers,

Mark