### PR TITLE
Add parentheses to pipes with arguments

### DIFF
--- a/bench/int_reply_bench.exs
+++ b/bench/int_reply_bench.exs
@@ -6,7 +6,7 @@ defmodule IntReplyBench do
   end
 
   bench "int_reply", [c: bench_context] do
-    c |> Exredis.Api.set "mykey", 42
-    c |> Exredis.Api.incr "mykey"
+    c |> Exredis.Api.set("mykey", 42)
+    c |> Exredis.Api.incr("mykey")
   end
 end

--- a/lib/exredis.ex
+++ b/lib/exredis.ex
@@ -28,7 +28,7 @@ defmodule Exredis do
       Exception.format_stacktrace
 
     start_link(host, port, database, password, reconnect_sleep)
-    |> elem 1
+    |> elem(1)
   end
 
 
@@ -40,7 +40,7 @@ defmodule Exredis do
 
     config = Exredis.Config.fetch_env
     start_link(config.host, config.port, config.db, config.password, config.reconnect)
-    |> elem 1
+    |> elem(1)
   end
 
   @doc """

--- a/lib/exredis/api.ex
+++ b/lib/exredis/api.ex
@@ -193,7 +193,7 @@ defmodule Exredis.Api do
   end
 
   defp multi_int_reply(reply), do:
-    reply |> Enum.map &int_reply/1
+    reply |> Enum.map(&int_reply/1)
 
   defp sts_reply("OK"), do:
     :ok

--- a/lib/exredis/script.ex
+++ b/lib/exredis/script.ex
@@ -11,7 +11,7 @@ defmodule Exredis.Script do
       def unquote(name)(client, keys \\ [], argv \\ []) do
         query_args = [length(keys)] ++ keys ++ argv
         case Exredis.query client, ["EVALSHA", unquote(script_sha)] ++ query_args do
-          <<"NOSCRIPT", _ :: binary>> -> 
+          <<"NOSCRIPT", _ :: binary>> ->
             load_script client, unquote(script)
             unquote(name)(client, keys, argv)
           reply -> reply
@@ -24,7 +24,7 @@ defmodule Exredis.Script do
     case Exredis.query client, ["SCRIPT", "LOAD", script] do
       <<"ERR", error :: binary>> ->
         throw error
-      reply -> 
+      reply ->
         reply
     end
   end

--- a/lib/exredis/sub.ex
+++ b/lib/exredis/sub.ex
@@ -37,7 +37,7 @@ defmodule Exredis.Sub do
       Exception.format_stacktrace
 
     start_link(host, port, password, reconnect, max_queue, behaviour)
-    |> elem 1
+    |> elem(1)
   end
   @doc false
   @spec start :: pid
@@ -48,7 +48,7 @@ defmodule Exredis.Sub do
     config = Exredis.Config.fetch_env
 
     start_link(config.host, config.port, config.password, config.reconnect, config.max_queue, config.behaviour)
-    |> elem 1    
+    |> elem(1)
   end
 
   @doc """

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -4,10 +4,10 @@ defmodule ApiMixin do
   import Exredis.Api
 
   def set(client), do:
-    client |> set "key", "value"
+    client |> set("key", "value")
 
   def get(client), do:
-    client |> get "key"
+    client |> get("key")
 
 end
 
@@ -20,8 +20,8 @@ defmodule ApiTest do
     {:ok, client} = E.start_link
 
     # clean up database and set test value
-    client |> E.query ["FLUSHALL"]
-    client |> E.query ["SET", "key", "value"]
+    client |> E.query(["FLUSHALL"])
+    client |> E.query(["SET", "key", "value"])
 
     { :ok, [c: client] }
   end
@@ -36,28 +36,28 @@ defmodule ApiTest do
   ##
 
   test "del", c do
-    assert (c[:c] |> R.del "key") == 1
-    assert (c[:c] |> R.del ["key1", "key2"]) == 0
-  end
+    assert (c[:c] |> R.del("key")) == 1
+    assert (c[:c] |> R.del(["key1", "key2"])) == 0
+    end
 
   test "keys", c do
     c[:c] |> R.flushall
-    c[:c] |> R.mset ["k1", "v1", "k2", "v2"]
+    c[:c] |> R.mset(["k1", "v1", "k2", "v2"])
 
-    assert length(c[:c] |> R.keys "k*") == 2
+    assert length(c[:c] |> R.keys("k*")) == 2
   end
 
   test "pexpire", c do
-    assert (c[:c] |> R.pexpire "key", "1500") == 1
-    assert (c[:c] |> R.pexpire "non-existing-key", "1500") == 0
+    assert (c[:c] |> R.pexpire("key", "1500")) == 1
+    assert (c[:c] |> R.pexpire("non-existing-key", "1500")) == 0
   end
 
   test "renamenx", c do
-    assert (c[:c] |> R.renamenx "key", "new_key") == 1
+    assert (c[:c] |> R.renamenx("key", "new_key")) == 1
   end
 
   test "dump", c do
-    assert is_binary(c[:c] |> R.dump "key") == true
+    assert is_binary(c[:c] |> R.dump("key")) == true
   end
 
   test "migrate", _c do
@@ -65,8 +65,8 @@ defmodule ApiTest do
   end
 
   test "pexpireat", c do
-    assert (c[:c] |> R.pexpireat "key", "1500") == 1
-    assert (c[:c] |> R.pexpireat "non-existing-key", "1500") == 0
+    assert (c[:c] |> R.pexpireat("key", "1500")) == 1
+    assert (c[:c] |> R.pexpireat("non-existing-key", "1500")) == 0
   end
 
   test "restore", _c do
@@ -74,8 +74,8 @@ defmodule ApiTest do
   end
 
   test "exists", c do
-    assert (c[:c] |> R.exists "key") == 1
-    assert (c[:c] |> R.exists "non-existing-key") == 0
+    assert (c[:c] |> R.exists("key")) == 1
+    assert (c[:c] |> R.exists("non-existing-key")) == 0
   end
 
   test "move", _c do
@@ -83,7 +83,7 @@ defmodule ApiTest do
   end
 
   test "pttl", c do
-    assert (c[:c] |> R.pttl "key") == -1
+    assert (c[:c] |> R.pttl("key")) == -1
   end
 
   test "sort", _c do
@@ -91,8 +91,8 @@ defmodule ApiTest do
   end
 
   test "expire", c do
-    assert (c[:c] |> R.expire "key", "1500") == 1
-    assert (c[:c] |> R.expire "non-existing-key", "1500") == 0
+    assert (c[:c] |> R.expire("key", "1500")) == 1
+    assert (c[:c] |> R.expire("non-existing-key", "1500")) == 0
   end
 
   test "object", _c do
@@ -104,23 +104,23 @@ defmodule ApiTest do
   end
 
   test "ttl", c do
-    assert (c[:c] |> R.ttl "key") == -1
+    assert (c[:c] |> R.ttl("key")) == -1
   end
 
   test "expireat", c do
-    assert (c[:c] |> R.expireat "key", "1293840000") == 1
+    assert (c[:c] |> R.expireat("key", "1293840000")) == 1
   end
 
   test "persist", c do
-    assert (c[:c] |> R.persist "key") == 0
+    assert (c[:c] |> R.persist("key")) == 0
   end
 
   test "rename", c do
-    assert (c[:c] |> R.rename "key", "new_key") == :ok
+    assert (c[:c] |> R.rename("key", "new_key")) == :ok
   end
 
   test "type", c do
-    assert (c[:c] |> R.type "key") == "string"
+    assert (c[:c] |> R.type("key")) == "string"
   end
 
   ##
@@ -128,118 +128,118 @@ defmodule ApiTest do
   ##
 
   test "append", c do
-    assert (c[:c] |> R.append "mykey", "hello") == 5
-    assert (c[:c] |> R.append "mykey", " world") == 11
-    assert (c[:c] |> R.get "mykey") == "hello world"
+    assert (c[:c] |> R.append("mykey", "hello")) == 5
+    assert (c[:c] |> R.append("mykey", " world")) == 11
+    assert (c[:c] |> R.get("mykey")) == "hello world"
   end
 
   test "bitcount", c do
-    assert (c[:c] |> R.set "mykey", "foobar") == :ok
-    assert (c[:c] |> R.bitcount "mykey") == 26
-    assert (c[:c] |> R.bitcount "mykey", 0, 0) == 4
-    assert (c[:c] |> R.bitcount "mykey", 1, 1) == 6
+    assert (c[:c] |> R.set("mykey", "foobar")) == :ok
+    assert (c[:c] |> R.bitcount("mykey")) == 26
+    assert (c[:c] |> R.bitcount("mykey", 0, 0)) == 4
+    assert (c[:c] |> R.bitcount("mykey", 1, 1)) == 6
   end
 
   test "decr", c do
-    assert (c[:c] |> R.set "mykey", 10) == :ok
-    assert (c[:c] |> R.decr "mykey") == 9
+    assert (c[:c] |> R.set("mykey", 10)) == :ok
+    assert (c[:c] |> R.decr("mykey")) == 9
   end
 
   test "decrby", c do
-    assert (c[:c] |> R.set "mykey", 10) == :ok
-    assert (c[:c] |> R.decrby "mykey", 5) == 5
+    assert (c[:c] |> R.set("mykey", 10)) == :ok
+    assert (c[:c] |> R.decrby("mykey", 5)) == 5
   end
 
   test "get", c do
-    assert (c[:c] |> R.get "key") == "value"
+    assert (c[:c] |> R.get("key")) == "value"
   end
 
   test "getbit", c do
-    assert (c[:c] |> R.setbit "bitkey", 7, 1) == 0
-    assert (c[:c] |> R.getbit "bitkey", 0) == 0
-    assert (c[:c] |> R.getbit "bitkey", 7) == 1
+    assert (c[:c] |> R.setbit("bitkey", 7, 1)) == 0
+    assert (c[:c] |> R.getbit("bitkey", 0)) == 0
+    assert (c[:c] |> R.getbit("bitkey", 7)) == 1
   end
 
   test "getrange", c do
-    assert (c[:c] |> R.set "mykey", "This is a string") == :ok
-    assert (c[:c] |> R.getrange "mykey", 0, 3) == "This"
-    assert (c[:c] |> R.getrange "mykey", -3, -1) == "ing"
-    assert (c[:c] |> R.getrange "mykey", 0, -1) == "This is a string"
-    assert (c[:c] |> R.getrange "mykey", 10, 100) == "string"
+    assert (c[:c] |> R.set("mykey", "This is a string")) == :ok
+    assert (c[:c] |> R.getrange("mykey", 0, 3)) == "This"
+    assert (c[:c] |> R.getrange("mykey", -3, -1)) == "ing"
+    assert (c[:c] |> R.getrange("mykey", 0, -1)) == "This is a string"
+    assert (c[:c] |> R.getrange("mykey", 10, 100)) == "string"
   end
 
   test "getset", c do
-    assert (c[:c] |> R.set "mykey", "val") == :ok
-    assert (c[:c] |> R.getset "mykey", "new") == "val"
-    assert (c[:c] |> R.get "mykey") == "new"
+    assert (c[:c] |> R.set("mykey", "val")) == :ok
+    assert (c[:c] |> R.getset("mykey", "new")) == "val"
+    assert (c[:c] |> R.get("mykey")) == "new"
   end
 
   test "incr", c do
-    assert (c[:c] |> R.set "mykey", 10) == :ok
-    assert (c[:c] |> R.incr "mykey") == 11
-    assert (c[:c] |> R.get "mykey") == "11"
+    assert (c[:c] |> R.set("mykey", 10)) == :ok
+    assert (c[:c] |> R.incr("mykey")) == 11
+    assert (c[:c] |> R.get("mykey")) == "11"
   end
 
   test "incrby", c do
-    assert (c[:c] |> R.set "mykey", 10) == :ok
-    assert (c[:c] |> R.incrby "mykey", 5) == 15
-    assert (c[:c] |> R.get "mykey") == "15"
+    assert (c[:c] |> R.set("mykey", 10)) == :ok
+    assert (c[:c] |> R.incrby("mykey", 5)) == 15
+    assert (c[:c] |> R.get("mykey")) == "15"
   end
 
   test "incrbyfloat", c do
-    assert (c[:c] |> R.set "mykey", "10.50") == :ok
-    assert (c[:c] |> R.incrbyfloat "mykey", "0.1") == "10.6"
-    assert (c[:c] |> R.get "mykey") == "10.6"
+    assert (c[:c] |> R.set("mykey", "10.50")) == :ok
+    assert (c[:c] |> R.incrbyfloat("mykey", "0.1")) == "10.6"
+    assert (c[:c] |> R.get("mykey")) == "10.6"
   end
 
   test "info", c do
-    assert is_nil(c[:c] |> R.info "stats") == false
+    assert is_nil(c[:c] |> R.info("stats")) == false
   end
 
   test "set", c do
-    assert (c[:c] |> R.set "key-2", "value-2") == :ok
-    assert (c[:c] |> R.get "key-2") == "value-2"
+    assert (c[:c] |> R.set("key-2", "value-2")) == :ok
+    assert (c[:c] |> R.get("key-2")) == "value-2"
   end
 
   test "setbit", c do
-    assert (c[:c] |> R.setbit "bitkey", 7, 1) == 0
-    assert (c[:c] |> R.setbit "bitkey", 7, 0) == 1
-    assert (c[:c] |> R.get "bitkey") == <<0>>
+    assert (c[:c] |> R.setbit("bitkey", 7, 1)) == 0
+    assert (c[:c] |> R.setbit("bitkey", 7, 0)) == 1
+    assert (c[:c] |> R.get("bitkey")) == <<0>>
   end
 
   test "setex", c do
-    assert (c[:c] |> R.setex "mykey", 10, "Hello") == :ok
-    assert (c[:c] |> R.ttl "mykey") == 10
-    assert (c[:c] |> R.get "mykey") == "Hello"
+    assert (c[:c] |> R.setex("mykey", 10, "Hello")) == :ok
+    assert (c[:c] |> R.ttl("mykey")) == 10
+    assert (c[:c] |> R.get("mykey")) == "Hello"
   end
 
   test "setnx", c do
-    assert (c[:c] |> R.setnx "mykey", "Hello") == 1
-    assert (c[:c] |> R.setnx "mykey", "World") == 0
-    assert (c[:c] |> R.get "mykey") == "Hello"
+    assert (c[:c] |> R.setnx("mykey", "Hello")) == 1
+    assert (c[:c] |> R.setnx("mykey", "World")) == 0
+    assert (c[:c] |> R.get("mykey")) == "Hello"
   end
 
   test "setrange", c do
-    assert (c[:c] |> R.set "mykey", "Hello World") == :ok
-    assert (c[:c] |> R.setrange "mykey", 6, "Redis") == 11
-    assert (c[:c] |> R.get "mykey") == "Hello Redis"
+    assert (c[:c] |> R.set("mykey", "Hello World")) == :ok
+    assert (c[:c] |> R.setrange("mykey", 6, "Redis")) == 11
+    assert (c[:c] |> R.get("mykey")) == "Hello Redis"
   end
 
   test "strlen", c do
-    assert (c[:c] |> R.set "mykey", "Hello World") == :ok
-    assert (c[:c] |> R.strlen "mykey") == 11
-    assert (c[:c] |> R.strlen "nonexisting") == 0
+    assert (c[:c] |> R.set("mykey", "Hello World")) == :ok
+    assert (c[:c] |> R.strlen("mykey")) == 11
+    assert (c[:c] |> R.strlen("nonexisting")) == 0
   end
 
   test "mset", c do
-    assert (c[:c] |> R.mset ["k1", "v1", "k2", "v2"]) == :ok
-    assert (c[:c] |> R.get "k1") == "v1"
-    assert (c[:c] |> R.get "k2") == "v2"
+    assert (c[:c] |> R.mset(["k1", "v1", "k2", "v2"])) == :ok
+    assert (c[:c] |> R.get("k1")) == "v1"
+    assert (c[:c] |> R.get("k2")) == "v2"
   end
 
   test "mget", c do
-    assert (c[:c] |> R.mset ["k1", "v1", "k2", "v2"]) == :ok
-    assert (c[:c] |> R.mget ["k1", "k2"]) == ["v1", "v2"]
+    assert (c[:c] |> R.mset(["k1", "v1", "k2", "v2"])) == :ok
+    assert (c[:c] |> R.mget(["k1", "k2"])) == ["v1", "v2"]
   end
 
   ##
@@ -247,82 +247,82 @@ defmodule ApiTest do
   ##
 
   test "hdel", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "foo") == 1
-    assert (c[:c] |> R.hdel "myhash", "field1") == 1
-    assert (c[:c] |> R.hdel "myhash", "field2") == 0
+    assert (c[:c] |> R.hset("myhash", "field1", "foo")) == 1
+    assert (c[:c] |> R.hdel("myhash", "field1")) == 1
+    assert (c[:c] |> R.hdel("myhash", "field2")) == 0
   end
 
   test "hexists", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "foo") == 1
-    assert (c[:c] |> R.hexists "myhash", "field1") == 1
-    assert (c[:c] |> R.hexists "myhash", "field2") == 0
+    assert (c[:c] |> R.hset("myhash", "field1", "foo")) == 1
+    assert (c[:c] |> R.hexists("myhash", "field1")) == 1
+    assert (c[:c] |> R.hexists("myhash", "field2")) == 0
   end
 
   test "hgetall", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "Hello") == 1
-    assert (c[:c] |> R.hset "myhash", "field2", "World") == 1
-    assert (c[:c] |> R.hgetall "myhash") == %{"field1" => "Hello", "field2" => "World"}
+    assert (c[:c] |> R.hset("myhash", "field1", "Hello")) == 1
+    assert (c[:c] |> R.hset("myhash", "field2", "World")) == 1
+    assert (c[:c] |> R.hgetall("myhash")) == %{"field1" => "Hello", "field2" => "World"}
   end
 
   test "hincrby", c do
-    assert (c[:c] |> R.hset "myhash", "field", 5) == 1
-    assert (c[:c] |> R.hincrby "myhash", "field", 1) == 6
-    assert (c[:c] |> R.hincrby "myhash", "field", -1) == 5
-    assert (c[:c] |> R.hincrby "myhash", "field", -10) == -5
+    assert (c[:c] |> R.hset("myhash", "field", 5)) == 1
+    assert (c[:c] |> R.hincrby("myhash", "field", 1)) == 6
+    assert (c[:c] |> R.hincrby("myhash", "field", -1)) == 5
+    assert (c[:c] |> R.hincrby("myhash", "field", -10)) == -5
   end
 
   test "hincrbyfloat", c do
-    assert (c[:c] |> R.hset "myhash", "field", "10.50") == 1
-    assert (c[:c] |> R.hincrbyfloat "myhash", "field", "0.1") == "10.6"
-    assert (c[:c] |> R.hset "myhash", "field", "5.0e3") == 0
-    assert (c[:c] |> R.hincrbyfloat "myhash", "field", "2.0e2") == "5200"
+    assert (c[:c] |> R.hset("myhash", "field", "10.50")) == 1
+    assert (c[:c] |> R.hincrbyfloat("myhash", "field", "0.1")) == "10.6"
+    assert (c[:c] |> R.hset("myhash", "field", "5.0e3")) == 0
+    assert (c[:c] |> R.hincrbyfloat("myhash", "field", "2.0e2")) == "5200"
   end
 
   test "hkeys", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "Hello") == 1
-    assert (c[:c] |> R.hset "myhash", "field2", "World") == 1
-    assert (c[:c] |> R.hkeys "myhash") == ["field1", "field2"]
+    assert (c[:c] |> R.hset("myhash", "field1", "Hello")) == 1
+    assert (c[:c] |> R.hset("myhash", "field2", "World")) == 1
+    assert (c[:c] |> R.hkeys("myhash")) == ["field1", "field2"]
   end
 
   test "hlen", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "Hello") == 1
-    assert (c[:c] |> R.hset "myhash", "field2", "World") == 1
-    assert (c[:c] |> R.hlen "myhash") == 2
+    assert (c[:c] |> R.hset("myhash", "field1", "Hello")) == 1
+    assert (c[:c] |> R.hset("myhash", "field2", "World")) == 1
+    assert (c[:c] |> R.hlen("myhash")) == 2
   end
 
   test "hmget", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "Hello") == 1
-    assert (c[:c] |> R.hset "myhash", "field2", "World") == 1
-    assert (c[:c] |> R.hmget "myhash", ["field1", "field2", "nofield"]) == ["Hello", "World", :undefined]
+    assert (c[:c] |> R.hset("myhash", "field1", "Hello")) == 1
+    assert (c[:c] |> R.hset("myhash", "field2", "World")) == 1
+    assert (c[:c] |> R.hmget("myhash", ["field1", "field2", "nofield"])) == ["Hello", "World", :undefined]
   end
 
   test "hmset", c do
-    assert (c[:c] |> R.hmset "myhash", ["field1", "Hello", "field2", "World"]) == :ok
-    assert (c[:c] |> R.hget "myhash", "field1") == "Hello"
-    assert (c[:c] |> R.hget "myhash", "field2") == "World"
+    assert (c[:c] |> R.hmset("myhash", ["field1", "Hello", "field2", "World"])) == :ok
+    assert (c[:c] |> R.hget("myhash", "field1")) == "Hello"
+    assert (c[:c] |> R.hget("myhash", "field2")) == "World"
   end
 
   test "hget", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "foo") == 1
-    assert (c[:c] |> R.hget "myhash", "field1") == "foo"
-    assert (c[:c] |> R.hget "myhash", "field2") == :undefined
+    assert (c[:c] |> R.hset("myhash", "field1", "foo")) == 1
+    assert (c[:c] |> R.hget("myhash", "field1")) == "foo"
+    assert (c[:c] |> R.hget("myhash", "field2")) == :undefined
   end
 
   test "hset", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "Hello") == 1
-    assert (c[:c] |> R.hget "myhash", "field1") == "Hello"
+    assert (c[:c] |> R.hset("myhash", "field1", "Hello")) == 1
+    assert (c[:c] |> R.hget("myhash", "field1")) == "Hello"
   end
 
   test "hsetnx", c do
-    assert (c[:c] |> R.hsetnx "myhash", "field", "Hello") == 1
-    assert (c[:c] |> R.hsetnx "myhash", "field", "World") == 0
-    assert (c[:c] |> R.hget "myhash", "field") == "Hello"
+    assert (c[:c] |> R.hsetnx("myhash", "field", "Hello")) == 1
+    assert (c[:c] |> R.hsetnx("myhash", "field", "World")) == 0
+    assert (c[:c] |> R.hget("myhash", "field")) == "Hello"
   end
 
   test "hvals", c do
-    assert (c[:c] |> R.hset "myhash", "field1", "Hello") == 1
-    assert (c[:c] |> R.hset "myhash", "field2", "World") == 1
-    assert (c[:c] |> R.hvals "myhash") == ["Hello", "World"]
+    assert (c[:c] |> R.hset("myhash", "field1", "Hello")) == 1
+    assert (c[:c] |> R.hset("myhash", "field2", "World")) == 1
+    assert (c[:c] |> R.hvals("myhash")) == ["Hello", "World"]
   end
 
   ##
@@ -331,8 +331,8 @@ defmodule ApiTest do
 
   test "multi", c do
     assert (c[:c] |> R.multi) == "OK"
-    assert (c[:c] |> R.set "incrm", 0) == "QUEUED"
-    assert (c[:c] |> R.incr "incrm") == "QUEUED"
+    assert (c[:c] |> R.set("incrm", 0)) == "QUEUED"
+    assert (c[:c] |> R.incr("incrm")) == "QUEUED"
     assert (c[:c] |> R.exec) == ["OK", "1"]
   end
 
@@ -341,7 +341,7 @@ defmodule ApiTest do
   ##
 
   test "publish", c do
-    assert (c[:c] |> R.publish "ch", "msg") == 0
+    assert (c[:c] |> R.publish("ch", "msg")) == 0
   end
 
   ##
@@ -350,7 +350,7 @@ defmodule ApiTest do
 
   test "flushall", c do
     assert (c[:c] |> R.flushall) == :ok
-    assert (c[:c] |> R.get "key") == :undefined
+    assert (c[:c] |> R.get("key")) == :undefined
   end
 
 end

--- a/test/exredis_test.exs
+++ b/test/exredis_test.exs
@@ -4,8 +4,8 @@ defmodule Pi do
   import Exredis
 
   # set/get
-  def get, do: start_link |> elem(1) |> query ["GET", "Pi"]
-  def set, do: start_link |> elem(1) |> query ["SET", "Pi", "3.14"]
+  def get, do: start_link |> elem(1) |> query(["GET", "Pi"])
+  def set, do: start_link |> elem(1) |> query(["SET", "Pi", "3.14"])
 end
 
 defmodule ExredisTest do
@@ -16,14 +16,14 @@ defmodule ExredisTest do
     {:ok, client} = E.start_link
 
     # clean up database and set test value
-    client |> E.query ["FLUSHALL"]
-    client |> E.query ["SET", "key", "value"]
+    client |> E.query(["FLUSHALL"])
+    client |> E.query(["SET", "key", "value"])
 
     { :ok, [c: client] }
   end
 
   test "mixin Pi.get", ctx do
-    ctx[:c] |> E.query ["SET", "Pi", "3.14"]
+    ctx[:c] |> E.query(["SET", "Pi", "3.14"])
 
     assert Pi.get == "3.14"
   end
@@ -31,7 +31,7 @@ defmodule ExredisTest do
   test "mixin Pi.set", ctx do
     Pi.set
 
-    assert (ctx[:c] |> E.query ["GET", "Pi"]) == "3.14"
+    assert (ctx[:c] |> E.query(["GET", "Pi"])) == "3.14"
   end
 
   test "connect" do
@@ -53,29 +53,29 @@ defmodule ExredisTest do
   end
 
   test "set returns OK", ctx do
-    assert (ctx[:c] |> E.query ["SET", "foo", "bar"]) == "OK"
+    assert (ctx[:c] |> E.query(["SET", "foo", "bar"])) == "OK"
   end
 
   test "set works", ctx do
-    ctx[:c] |> E.query ["SET", "foo", "bar"]
+    ctx[:c] |> E.query(["SET", "foo", "bar"])
 
-    assert (ctx[:c] |> E.query ["GET", "foo"]) == "bar"
+    assert (ctx[:c] |> E.query(["GET", "foo"])) == "bar"
   end
 
   test "get", ctx do
-    assert (ctx[:c] |> E.query ["GET", "key"]) == "value"
+    assert (ctx[:c] |> E.query(["GET", "key"])) == "value"
   end
 
   test "mset returns OK", ctx do
     values = ["key1", "value1", "key2", "value2"]
 
-    assert (ctx[:c] |> E.query ["MSET" | values]) == "OK"
+    assert (ctx[:c] |> E.query(["MSET" | values])) == "OK"
   end
 
   test "mset works", ctx do
-    ctx[:c] |> E.query ["MSET" | ["key1", "value1", "key2", "value2"]]
+    ctx[:c] |> E.query(["MSET" | ["key1", "value1", "key2", "value2"]])
 
-    values = ctx[:c] |> E.query ["MGET" | ["key1", "key2"]]
+    values = ctx[:c] |> E.query(["MGET" | ["key1", "key2"]])
 
     assert values == ["value1", "value2"]
   end
@@ -108,7 +108,7 @@ defmodule ExredisTest do
   end
 
   test "explicit timeout", ctx do
-    {reason, _} = catch_exit(ctx[:c] |> E.query ["INFO"], 0)
+    {reason, _} = catch_exit(ctx[:c] |> E.query(["INFO"], 0))
     assert reason == :timeout
   end
 end

--- a/test/pubsub_test.exs
+++ b/test/pubsub_test.exs
@@ -29,24 +29,24 @@ defmodule PubsubTest do
     {:ok, client} = E.start_link
     pid = Kernel.self
 
-    client_sub |> S.subscribe "foo", fn(msg) ->
+    client_sub |> S.subscribe("foo", fn(msg) ->
       send(pid, msg)
-    end
+    end)
 
     receive do
       msg ->
-        assert (msg |> elem 0) == :subscribed
-        assert (msg |> elem 1) == "foo"
+        assert (msg |> elem(0)) == :subscribed
+        assert (msg |> elem(1)) == "foo"
 
     end
 
-    client |> R.publish "foo", "Hello World!"
+    client |> R.publish("foo", "Hello World!")
 
     receive do
       msg ->
-        assert (msg |> elem 0) == :message
-        assert (msg |> elem 1) == "foo"
-        assert (msg |> elem 2) == "Hello World!"
+        assert (msg |> elem(0)) == :message
+        assert (msg |> elem(1)) == "foo"
+        assert (msg |> elem(2)) == "Hello World!"
 
     end
   end
@@ -57,29 +57,29 @@ defmodule PubsubTest do
     {:ok, client} = E.start_link
     pid = Kernel.self
 
-    client_sub |> S.subscribe ["foo", "bar"], fn(msg) ->
+    client_sub |> S.subscribe(["foo", "bar"], fn(msg) ->
       send(pid, msg)
+    end)
+
+    receive do
+      msg ->
+        assert (msg |> elem(0)) == :subscribed
+        assert (msg |> elem(1)) == "foo"
     end
 
     receive do
       msg ->
-        assert (msg |> elem 0) == :subscribed
-        assert (msg |> elem 1) == "foo"
+        assert (msg |> elem(0)) == :subscribed
+        assert (msg |> elem(1)) == "bar"
     end
+
+    client |> R.publish("foo", "Hello World!")
 
     receive do
       msg ->
-        assert (msg |> elem 0) == :subscribed
-        assert (msg |> elem 1) == "bar"
-    end
-
-    client |> R.publish "foo", "Hello World!"
-
-    receive do
-      msg ->
-        assert (msg |> elem 0) == :message
-        assert (msg |> elem 1) == "foo"
-        assert (msg |> elem 2) == "Hello World!"
+        assert (msg |> elem(0)) == :message
+        assert (msg |> elem(1)) == "foo"
+        assert (msg |> elem(2)) == "Hello World!"
 
     end
   end
@@ -90,25 +90,25 @@ defmodule PubsubTest do
     {:ok, client} = E.start_link
     pid = Kernel.self
 
-    client_sub |> S.psubscribe "bar_*", fn(msg) ->
+    client_sub |> S.psubscribe("bar_*", fn(msg) ->
       send(pid, msg)
-    end
+    end)
 
     receive do
       msg ->
-        assert (msg |> elem 0) == :subscribed
-        assert (msg |> elem 1) == "bar_*"
+        assert (msg |> elem(0)) == :subscribed
+        assert (msg |> elem(1)) == "bar_*"
 
     end
 
-    client |> R.publish "bar_test", "Hello World!"
+    client |> R.publish("bar_test", "Hello World!")
 
     receive do
       msg ->
-        assert (msg |> elem 0) == :pmessage
-        assert (msg |> elem 1) == "bar_*"
-        assert (msg |> elem 2) == "bar_test"
-        assert (msg |> elem 3) == "Hello World!"
+        assert (msg |> elem(0)) == :pmessage
+        assert (msg |> elem(1)) == "bar_*"
+        assert (msg |> elem(2)) == "bar_test"
+        assert (msg |> elem(3)) == "Hello World!"
 
     end
   end

--- a/test/script_test.exs
+++ b/test/script_test.exs
@@ -20,9 +20,9 @@ defmodule ScriptTest do
     {:ok, client} = E.start_link
 
     # clean up database and set test value
-    client |> E.query ["FLUSHALL"]
-    client |> E.query ["SET", "key1", "value1"]
-    client |> E.query ["SET", "key2", "value2"]
+    client |> E.query(["FLUSHALL"])
+    client |> E.query(["SET", "key1", "value1"])
+    client |> E.query(["SET", "key2", "value2"])
 
     { :ok, [c: client] }
   end


### PR DESCRIPTION
Elixir now warns if piping into something with args:

```elixir
value |> SomeModule.foo some, args
```

This results in compile warnings because it might cause ambiguous behaviour.