### PR TITLE
Update outdated dependencies

### DIFF
--- a/bench/int_reply_bench.exs
+++ b/bench/int_reply_bench.exs
@@ -2,7 +2,7 @@ defmodule IntReplyBench do
   use Benchfella
 
   setup_all do
-    {:ok, Exredis.start}
+    {:ok, Exredis.start_using_connection_string}
   end
 
   bench "int_reply", [c: bench_context] do

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Exredis.Mixfile do
   # Dependencies
   defp deps do
     [{:eredis,  ">= 1.0.8"},
-     {:benchfella, "~> 0.2.0", only: :dev},
+     {:benchfella, "~> 0.3.0", only: :dev},
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.7", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"benchfella": {:hex, :benchfella, "0.2.1"},
-  "earmark": {:hex, :earmark, "0.1.17"},
+%{"benchfella": {:hex, :benchfella, "0.3.1"},
+  "earmark": {:hex, :earmark, "0.2.1"},
   "eredis": {:hex, :eredis, "1.0.8"},
-  "ex_doc": {:hex, :ex_doc, "0.7.3"},
+  "ex_doc": {:hex, :ex_doc, "0.11.3"},
   "inch_ex": {:hex, :inch_ex, "0.3.3"},
   "poison": {:hex, :poison, "1.4.0"}}


### PR DESCRIPTION
- Update to latest deps available using `mix deps.update --all`
- Update benchfella by modifying mix.exs
- Make benchmarks use non-deprecated way of starting Exredis