### PR TITLE
Exredis.Api multiple keys example docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ client |> Api.get
 # => "value"
 ```
 
+__Using Exredis.Api with multiple keys__
+
+``` elixir
+{:ok, client} = Exredis.start_link
+
+client |> Exredis.Api.sadd("set1", "bar")
+# => "1"
+
+client |> Exredis.Api.sadd("set2", ["bar", "foo"])
+# => "2"
+
+client |> Exredis.Api.sdiff(["set2", "set1"])
+# => ["foo"]
+
+client |> Exredis.Api.sdiffstore("dest", ["set2", "set1"])
+# => "1"
+```
+
 __Connect to the Redis server__
 
 ```elixir


### PR DESCRIPTION
I was confused on how to use Exredis.Api methods where I need multiple keys, for example `sdiff(key)`. I didn't know, until I checked the source, that I can use `key` as a list. Maybe my examples will help someone in the future.