### PR TITLE
Use env config when an empty array is passed to start_link or allow to pass config

### DIFF
--- a/lib/exredis.ex
+++ b/lib/exredis.ex
@@ -44,6 +44,19 @@ defmodule Exredis do
   end
 
   @doc """
+  Connects to the Redis server, Erlang way:
+
+  * `start_link`
+
+  Returns a tuple `{:ok, pid}`.
+  """
+  @spec start_link :: start_link
+  def start_link([]) do
+    config = Exredis.Config.fetch_env
+    :eredis.start_link(String.to_char_list(config.host), config.port, config.db, String.to_char_list(config.password), config.reconnect)
+  end
+
+  @doc """
   Allows poolboy to connect to this by passing a list of args
   """
   def start_link(system_args) when is_list(system_args) do

--- a/lib/exredis.ex
+++ b/lib/exredis.ex
@@ -57,6 +57,18 @@ defmodule Exredis do
   end
 
   @doc """
+  Connects to the Redis server, Erlang way:
+
+  * `start_link`
+
+  Returns a tuple `{:ok, pid}`.
+  """
+  @spec start_link :: start_link
+  def start_link(%Exredis.Config.Config{} = config) do
+    :eredis.start_link(String.to_char_list(config.host), config.port, config.db, String.to_char_list(config.password), config.reconnect)
+  end
+
+  @doc """
   Allows poolboy to connect to this by passing a list of args
   """
   def start_link(system_args) when is_list(system_args) do


### PR DESCRIPTION
Hi ✋ ,

This is mainly because as far as I know there's no way to pass 0 arguments when using poolboy so I ended by doing:

```elixir
exredis_args = [
  host: config.host,
  port: config.port,
  database: config.db,
  password: config.password,
  reconnect_sleep: config.reconnect,
]

children = [
  :poolboy.child_spec(:exredis, pool_opts, exredis_args)
]
```

with this change this can be potentially reduced to 

```elixir
children = [
  :poolboy.child_spec(:exredis, pool_opts, [])
]
```

or 

```elixir
config = Exredis.Config.fetch_env
children = [
  :poolboy.child_spec(:exredis, pool_opts, [config])
]
```

I felt like it would be nice to handle both of those cases.

What do you think?