### PR TITLE
Introduce supervised connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,30 @@ end
 client |> MyScripts.lua_echo(["mykey"], ["foo"])
 # => "foo"
 ```
+
+__Supervised connections__
+
+If you want your connection to be supervised and automatically restarted when it crashes, you can use `Exredis.Connection` to register a supervised worker in the application bootstrap:
+
+```elixir
+worker(Exredis.Connection, [:myredis_proc, :myredis_conn, "redis://example.com:6379/0"])
+```
+
+You can then retrieve the registered client this way:
+
+```elixir
+import Exredis
+
+:my_redis_conn |> client |> query ["SET", "FOO", "BAR"]
+```
+
+`Exredis.Connection` also allows you to register multiple connections:
+
+```elixir
+worker(Exredis.Connection, [:myredis_proc1, :myredis_conn1, "redis://example.com:6379/0"], id: :my_worker1)
+worker(Exredis.Connection, [:myredis_proc2, :myredis_conn2, "redis://example.io:6379/0"], id: :my_worker2)
+```
+
 ---
 
 ### Contributing

--- a/lib/exredis.ex
+++ b/lib/exredis.ex
@@ -109,6 +109,17 @@ defmodule Exredis do
   end
 
   @doc """
+  Retrieves the Redis client registered with the given name:
+
+  `client name`
+
+  Returns the `pid` of the client.
+  """
+  @spec client(pid) :: pid
+  def client(name), do:
+    Exredis.Connection.client(name)
+
+  @doc """
   Disconnects from the Redis server:
 
   `stop client`

--- a/lib/exredis/connection.ex
+++ b/lib/exredis/connection.ex
@@ -1,0 +1,57 @@
+defmodule Exredis.Connection do
+  @moduledoc """
+  A GenServer used to manage a Redis connection in a fault-tolerant fashion.
+  """
+
+  use GenServer
+
+  @doc """
+  Starts a supervised process to manage all Redis requests for a given connection.
+  The process is registered with a given name so it can be restarted by its supervisor.
+
+  `start_link(:myredis_proc, :myredis_conn, "redis://example.com:6379/0")`
+
+  This is often called indirectly by registering a worker in the supervision tree when
+  bootstrapping an application:
+
+  `worker(Exredis.Connection, [:myredis_proc, :myredis_conn, "redis://example.com:6379/0"])`
+
+  Returns a tuple containing the status and pid of the linked process.
+  """
+  def start_link(proc_name, conn_name, uri) do
+    GenServer.start_link(__MODULE__, [conn_name, uri], name: proc_name)
+  end
+
+  @doc """
+  Invoked when the server is started, e.g. by calling `start_link/3`.
+  It starts and registers a linked process that acts as a Redis client for a given URI.
+  This is not meant to be called directly.
+  """
+  def init(state = [conn_name, uri]) do
+    Process.flag(:trap_exit, true)
+
+    uri
+    |> Exredis.start_using_connection_string
+    |> register_redis(conn_name)
+
+    Process.flag(:trap_exit, false)
+
+    {:ok, state}
+  end
+
+  @doc """
+  Retrieves the Redis client registered with the given name:
+
+  `client name`
+
+  Returns the `pid` of the client.
+  """
+  def client(conn_name), do: Process.whereis(conn_name)
+
+  defp register_redis({:connection_error, error}, _conn_name) do
+    raise "Could not connect to Redis with error: #{inspect(error)}"
+  end
+  defp register_redis(pid, conn_name) do
+    pid |> Process.register(conn_name)
+  end
+end

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -1,0 +1,22 @@
+Code.require_file "test_helper.exs", __DIR__
+
+defmodule ConnectionTest do
+  use ExUnit.Case
+
+  alias Exredis.Connection
+
+  setup do
+    pid = Connection.start_link(:proc_name, :conn_name, "redis://127.0.0.1:6379/0") |> elem(1)
+    {:ok, pid: pid}
+  end
+
+  test "start_link/2 registers processes with given proc name and conn name", %{pid: pid} do
+    assert pid |> is_pid
+    assert Process.whereis(:proc_name)
+    assert Process.whereis(:conn_name)
+  end
+
+  test "client/1 retrieves the Redis client registered with the given name", %{pid: _pid} do
+    assert Connection.client(:conn_name)
+  end
+end


### PR DESCRIPTION
I've created a GenServer used to manage a Redis connection. This allows the connection to be supervised and restarted in case of a crash. It also lets you register multiple connections in the supervision tree.