### PR TITLE
Changes the usage of the deprecated Enum.chunk

### DIFF
--- a/lib/exredis/api.ex
+++ b/lib/exredis/api.ex
@@ -70,7 +70,7 @@ defmodule Exredis.Api do
   defredis :hexists, [:key, :field], &int_reply/1
   defredis :hget, [:key, :field]
   defredis :hgetall, [:key], fn x ->
-    Enum.chunk(x, 2)
+    Enum.chunk_every(x, 2)
       |> Enum.map(fn [a, b] -> {a, b} end)
       |> Enum.into(Map.new)
   end


### PR DESCRIPTION
According to https://hexdocs.pm/elixir/master/compatibility-and-deprecations.html and mix warnings, `Enum.chunk` was deprecated in favor of `Enum.chunk_every`.